### PR TITLE
add config for the new kernal

### DIFF
--- a/joystick.py
+++ b/joystick.py
@@ -26,6 +26,8 @@ import uinput
 # Open SPI bus
 spi = spidev.SpiDev()
 spi.open(0,0)
+# Set the Max Hz make the MCP3008 work well for the new kernal
+spi.max_speed_hz=1000000
 
 # Function to read SPI data from MCP3008 chip
 # Channel must be an integer 0-7


### PR DESCRIPTION
add those config for the MCP3008 can work well with new kernal

https://www.raspberrypi.org/forums/viewtopic.php?f=44&t=213951&sid=67f4013eebf6b98103d19572ad33faa1

Re: ADC (MCP3008) Converter (for joysticks) no longer works, now always returns zero's
Quote
Sun Jun 03, 2018 8:38 pm

If an older Linux kernel is being used (<=4.8.y) the default max. SPI frequency is 500kHz, see https://github.com/raspberrypi/linux/bl ... b.dts#L126

If a newer Linux kernel is being used (>=4.9.y) the default max. SPI frequency is 125MHz, see https://github.com/raspberrypi/linux/bl ... b.dts#L131

An MCP3008 will work well at 500kHz but it will not work at 125MHz. If a newer kernel is being used it will be necessary to set spi.max_speed_hz to a value that the MCP3008 supports.